### PR TITLE
Corrects issue #14 

### DIFF
--- a/Snowplow.Tracker/Emitters/Emitter.cs
+++ b/Snowplow.Tracker/Emitters/Emitter.cs
@@ -304,7 +304,6 @@ namespace Snowplow.Tracker
             }
             catch (WebException we)
             {
-                OfflineHandle(payload);
                 return noResponseMessage;
             }
 
@@ -351,7 +350,6 @@ namespace Snowplow.Tracker
                 var response = (HttpWebResponse)we.Response;
                 if (response == null)
                 {
-                    OfflineHandle(payload);
                     return noResponseMessage;
                 }
                 response.Close();

--- a/Snowplow.Tracker/Emitters/Emitter.cs
+++ b/Snowplow.Tracker/Emitters/Emitter.cs
@@ -212,7 +212,10 @@ namespace Snowplow.Tracker
                 }
                 else
                 {
-                    Log.Logger.Warn(String.Format("POST request to {0} finished with status: '{1}'", collectorUri, statusCode));
+                    OfflineHandle(data);
+
+                    Log.Logger.Warn(String.Format("POST request to {0} finished with status: '{1}'. Sent to backup emitter.", collectorUri, statusCode));
+                    
                     if (onFailure != null)
                     {
                         onFailure(0, tempBuffer);
@@ -236,7 +239,8 @@ namespace Snowplow.Tracker
                     }
                     else
                     {
-                        Log.Logger.Warn(String.Format("GET request to {0} finished with status: '{1}'", collectorUri, statusCode));
+                        OfflineHandle(payload);
+                        Log.Logger.Warn(String.Format("GET request to {0} finished with status: '{1}'. Sent to backup emitter.", collectorUri, statusCode));
                         unsentRequests.Add(payload);
                     }
                 }

--- a/Snowplow.Tracker/Emitters/Emitter.cs
+++ b/Snowplow.Tracker/Emitters/Emitter.cs
@@ -409,6 +409,7 @@ namespace Snowplow.Tracker
                         allSent = false;
                         System.Messaging.Message evt = messageEnumerator.RemoveCurrent();
                         Input(jss.Deserialize<Dictionary<string, string>>(evt.Body.ToString()));
+
                     }
                 }
             }

--- a/Snowplow.Tracker/Snowplow.Tracker.csproj
+++ b/Snowplow.Tracker/Snowplow.Tracker.csproj
@@ -30,7 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NLog">
       <HintPath>packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>

--- a/Snowplow.Tracker/packages.config
+++ b/Snowplow.Tracker/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NLog" version="3.1.0.0" targetFramework="net45" />
   <package id="NLog.Config" version="3.1.0.0" targetFramework="net45" />
   <package id="NLog.Schema" version="3.1.0.0" targetFramework="net45" />


### PR DESCRIPTION
Send all "failed" events back through offlineHandle method. 
Updated Newtonsoft.Json to latest version 7.01.
Added lock to AsynEmitter flush method to stop random concurrency issues.
Tested additions with 4,500,000 events through the CloudFront collector.  MSMQ is functioning as expected.
Currently using in production environment.
