### PR TITLE
Release/1.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 1.0.1 (2017-02-22)
+--------------------------
+Update LiteDB dependency to 3.0.1 (#67)
+
 Version 1.0.0 (2017-02-15)
 --------------------------
 Add Xamarin demo application (#60) 

--- a/Nuget/Snowplow.Tracker.PlatformExtensions.nuspec
+++ b/Nuget/Snowplow.Tracker.PlatformExtensions.nuspec
@@ -3,7 +3,7 @@
     <metadata minClientVersion="2.8.3">
         <id>Snowplow.Tracker.PlatformExtensions</id>
         <copyright>Copyright 2017</copyright>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <title>Snowplow.Tracker.PlatformExtensions</title>
         <authors>Joshua Beemster</authors>
         <owners>snowplow</owners>
@@ -16,7 +16,7 @@
         <dependencies>
             <group targetFramework="netstandard1.4">
                 <dependency id="NETStandard.Library" version="1.6.1" />
-                <dependency id="Snowplow.Tracker" version="1.0.0" />
+                <dependency id="Snowplow.Tracker" version="1.0.1" />
             </group>
         </dependencies>
     </metadata>

--- a/Snowplow.Demo.App/Snowplow.Demo.App.Droid/Snowplow.Demo.App.Droid.csproj
+++ b/Snowplow.Demo.App/Snowplow.Demo.App.Droid/Snowplow.Demo.App.Droid.csproj
@@ -73,8 +73,8 @@
       <HintPath>..\..\packages\Xamarin.Forms.2.3.3.180\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\netstandard1.4\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\netstandard1.4\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -87,16 +87,16 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Snowplow.Tracker.PlatformExtensions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.0\lib\MonoAndroid10\Snowplow.Tracker.PlatformExtensions.dll</HintPath>
+      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.1\lib\MonoAndroid10\Snowplow.Tracker.PlatformExtensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Snowplow.Tracker.PlatformExtensions.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.0\lib\MonoAndroid10\Snowplow.Tracker.PlatformExtensions.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.1\lib\MonoAndroid10\Snowplow.Tracker.PlatformExtensions.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Demo.App/Snowplow.Demo.App.Droid/packages.config
+++ b/Snowplow.Demo.App/Snowplow.Demo.App.Droid/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="monoandroid60" />
+  <package id="LiteDB" version="3.0.1" targetFramework="monoandroid70" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="monoandroid60" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid60" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid60" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid60" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid60" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="monoandroid70" />
-  <package id="Snowplow.Tracker.PlatformExtensions" version="1.0.0" targetFramework="monoandroid70" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="monoandroid70" />
+  <package id="Snowplow.Tracker.PlatformExtensions" version="1.0.1" targetFramework="monoandroid70" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid60" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid60" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid60" />

--- a/Snowplow.Demo.App/Snowplow.Demo.App.iOS/Snowplow.Demo.App.iOS.csproj
+++ b/Snowplow.Demo.App/Snowplow.Demo.App.iOS/Snowplow.Demo.App.iOS.csproj
@@ -128,8 +128,8 @@
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\netstandard1.4\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\netstandard1.4\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -140,16 +140,16 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Snowplow.Tracker.PlatformExtensions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.0\lib\Xamarin.iOS10\Snowplow.Tracker.PlatformExtensions.dll</HintPath>
+      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.1\lib\Xamarin.iOS10\Snowplow.Tracker.PlatformExtensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Snowplow.Tracker.PlatformExtensions.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.0\lib\Xamarin.iOS10\Snowplow.Tracker.PlatformExtensions.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\Snowplow.Tracker.PlatformExtensions.1.0.1\lib\Xamarin.iOS10\Snowplow.Tracker.PlatformExtensions.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Demo.App/Snowplow.Demo.App.iOS/packages.config
+++ b/Snowplow.Demo.App/Snowplow.Demo.App.iOS/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="xamarinios10" />
+  <package id="LiteDB" version="3.0.1" targetFramework="xamarinios10" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="xamarinios10" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="xamarinios10" />
-  <package id="Snowplow.Tracker.PlatformExtensions" version="1.0.0" targetFramework="xamarinios10" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="xamarinios10" />
+  <package id="Snowplow.Tracker.PlatformExtensions" version="1.0.1" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />

--- a/Snowplow.Demo.App/Snowplow.Demo.App/project.json
+++ b/Snowplow.Demo.App/Snowplow.Demo.App/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.1",
-    "Snowplow.Tracker": "1.0.0",
-    "Snowplow.Tracker.PlatformExtensions": "1.0.0",
+    "Snowplow.Tracker": "1.0.1",
+    "Snowplow.Tracker.PlatformExtensions": "1.0.1",
     "Xamarin.Forms": "2.3.3.180"
   },
   "frameworks": {

--- a/Snowplow.Demo.Console/Program.cs
+++ b/Snowplow.Demo.Console/Program.cs
@@ -12,7 +12,7 @@
  * express or implied. See the Apache License Version 2.0 for the specific
  * language governing permissions and limitations there under.
  * Authors: Ed Lewis, Joshua Beemster
- * Copyright: Copyright (c) 2014-2016 Snowplow Analytics Ltd
+ * Copyright: Copyright (c) 2014-2017 Snowplow Analytics Ltd
  * License: Apache License Version 2.0
  */
 

--- a/Snowplow.Demo.Console/project.json
+++ b/Snowplow.Demo.Console/project.json
@@ -7,9 +7,9 @@
 
   "dependencies": {
     "System.Console": "4.3.0",
+    "Snowplow.Tracker": "1.0.1",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
-    "Microsoft.NETCore.DotNetHostPolicy": "1.0.1",
-    "Snowplow.Tracker": "*"
+    "Microsoft.NETCore.DotNetHostPolicy": "1.0.1"
   },
 
   "frameworks": {

--- a/Snowplow.Tracker.PlatformExtensions/DotnetTests/DotnetTests.csproj
+++ b/Snowplow.Tracker.PlatformExtensions/DotnetTests/DotnetTests.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\net35\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=3.0.1.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\net35\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -52,8 +52,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Tracker.PlatformExtensions/DotnetTests/packages.config
+++ b/Snowplow.Tracker.PlatformExtensions/DotnetTests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="net461" />
+  <package id="LiteDB" version="3.0.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="net461" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Abstractions/project.json
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Abstractions/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.1",
-    "Snowplow.Tracker": "1.0.0"
+    "Snowplow.Tracker": "1.0.1"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Dotnet461/Snowplow.Tracker.PlatformExtensions.Dotnet461.csproj
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Dotnet461/Snowplow.Tracker.PlatformExtensions.Dotnet461.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\Snowplow.Tracker.PlatformExtensions.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\net35\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=3.0.1.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\net35\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -48,8 +48,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Dotnet461/packages.config
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Dotnet461/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="net461" />
+  <package id="LiteDB" version="3.0.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="net461" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Droid/Snowplow.Tracker.PlatformExtensions.Droid.csproj
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Droid/Snowplow.Tracker.PlatformExtensions.Droid.csproj
@@ -38,8 +38,8 @@
     <DocumentationFile>bin\Release\Snowplow.Tracker.PlatformExtensions.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\netstandard1.4\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=3.0.1.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\netstandard1.4\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -52,8 +52,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Droid/packages.config
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.Droid/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="monoandroid60" />
+  <package id="LiteDB" version="3.0.1" targetFramework="monoandroid60" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="monoandroid60" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid60" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid60" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid60" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid60" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="monoandroid70" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="monoandroid60" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid60" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid60" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid60" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.iOS/Snowplow.Tracker.PlatformExtensions.iOS.csproj
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.iOS/Snowplow.Tracker.PlatformExtensions.iOS.csproj
@@ -45,8 +45,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="LiteDB, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LiteDB.3.0.0\lib\netstandard1.4\LiteDB.dll</HintPath>
+    <Reference Include="LiteDB, Version=3.0.1.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LiteDB.3.0.1\lib\netstandard1.4\LiteDB.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -57,8 +57,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Snowplow.Tracker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Snowplow.Tracker.1.0.0\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
+    <Reference Include="Snowplow.Tracker, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Snowplow.Tracker.1.0.1\lib\netstandard1.4\Snowplow.Tracker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.iOS/packages.config
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions.iOS/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.0.0" targetFramework="xamarinios10" />
+  <package id="LiteDB" version="3.0.1" targetFramework="xamarinios10" />
   <package id="Microsoft.Extensions.PlatformAbstractions" version="1.0.0" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="xamarinios10" />
-  <package id="Snowplow.Tracker" version="1.0.0" targetFramework="xamarinios10" />
+  <package id="Snowplow.Tracker" version="1.0.1" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />

--- a/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions/project.json
+++ b/Snowplow.Tracker.PlatformExtensions/Snowplow.Tracker.PlatformExtensions/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.1",
-    "Snowplow.Tracker": "1.0.0"
+    "Snowplow.Tracker": "1.0.1"
   },
   "frameworks": {
     "netstandard1.4": {}

--- a/Snowplow.Tracker.Tests/project.json
+++ b/Snowplow.Tracker.Tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "dotnet-test-mstest": "1.1.2-preview",
     "MSTest.TestFramework": "1.0.7-preview",
-    "Snowplow.Tracker": "1.0.0-*"
+    "Snowplow.Tracker": "1.0.1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/Snowplow.Tracker/Version.cs
+++ b/Snowplow.Tracker/Version.cs
@@ -20,6 +20,6 @@ namespace Snowplow.Tracker
 {
     public class Version
     {
-        public static string VERSION = "cs-1.0.0";
+        public static string VERSION = "cs-1.0.1";
     }
 }

--- a/Snowplow.Tracker/project.json
+++ b/Snowplow.Tracker/project.json
@@ -30,5 +30,5 @@
     ]
   },
   "title": "Snowplow.Tracker",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/Snowplow.Tracker/project.json
+++ b/Snowplow.Tracker/project.json
@@ -2,7 +2,7 @@
   "authors": [ "Fred Blundun, Joshua Beemster, Ed Lewis" ],
   "copyright": "Copyright 2014-2016",
   "dependencies": {
-    "LiteDB": "3.0.0",
+    "LiteDB": "3.0.1",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
     "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.1",


### PR DESCRIPTION
- [X] bump LiteDB dep in Snowplow.Tracker to 3.0.1
- [X] bump Snowplow.Tracker version to 1.0.1
- [X] bump Snowplow.Tracker.PlatformExtensions dep to Snowplow.Tracker 1.0.1
- [X] bump Snowplow.Tracker.PlatformExtensions version to 1.0.1
- [x] fix dotnet core demo to use 1.0.1 version of Snowplow.Tracker
- [x] fix Xamarin demo to use 1.0.1 version of Snowplow.Tracker.PlatformExtensions
- [x] upload Snowplow.Tracker 1.0.1 to nuget
- [x] upload Snowplow.Tracker.PlatformExtensions 1.0.1 to nuget
- [x] rebase to tickets
- [x] edit changelog
- [ ] merge
- [ ] create github release
