### PR TITLE
Release/1.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 1.2.2 (2023-03-21)
+--------------------------
+Fix upgrading storage database from previous versions of LiteDB (#131)
+Upgrade dependencies or modernize the Android Xamarin demo (#123)
+
 Version 1.2.1 (2023-03-01)
 --------------------------
 Upgrade LiteDB to 5.0.15

--- a/Snowplow.Tracker/Snowplow.Tracker.csproj
+++ b/Snowplow.Tracker/Snowplow.Tracker.csproj
@@ -4,7 +4,7 @@
     <Description>The Snowplow .NET Tracker lets you track your users' behaviour on your .NET desktop and mobile applications, websites and servers. Define your own custom events to suit your needs. Store your data in a scalable event data warehouse under your own control.</Description>
     <Copyright>Copyright 2023</Copyright>
     <AssemblyTitle>Snowplow.Tracker</AssemblyTitle>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
     <Authors>Fred Blundun, Joshua Beemster, Ed Lewis, Paul Boocock</Authors>
     <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Snowplow.Tracker</AssemblyName>
@@ -16,7 +16,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snowplow.Tracker/Storage/LiteDBStorage.cs
+++ b/Snowplow.Tracker/Storage/LiteDBStorage.cs
@@ -41,7 +41,10 @@ namespace Snowplow.Tracker.Storage
         /// <param name="path">Filename of database file (doesn't need to exist)</param>
         public LiteDBStorage(string path)
         {
-            _db = new LiteDatabase(path);
+            _db = new LiteDatabase(new ConnectionString(path)
+            {
+                Upgrade = true
+            });
             if (_db.CollectionExists(COLLECTION_NAME))
             {
                 TotalItems = _db.GetCollection<LiteDbStorageRecord>(COLLECTION_NAME).Count();

--- a/Snowplow.Tracker/Version.cs
+++ b/Snowplow.Tracker/Version.cs
@@ -15,6 +15,6 @@ namespace Snowplow.Tracker
 {
     public class Version
     {
-        public static string VERSION = "cs-1.2.1";
+        public static string VERSION = "cs-1.2.2";
     }
 }


### PR DESCRIPTION
Patch release that fixes a problem with upgrading event storage database created using tracker version older than 1.2.1 with the latest version which upgraded the LiteDB dependency to v5.

This release also updates the mobile demo app to work with the latest Xamarin frameworks.

**Changelog**

* Fix upgrading storage database from previous versions of LiteDB
* Upgrade dependencies or modernize the Android Xamarin demo (close #123)