### PR TITLE
Adding CustomGetPath and CustomPostPath methods

### DIFF
--- a/Snowplow.Tracker/Endpoints/SnowplowHttpCollectorEndpoint.cs
+++ b/Snowplow.Tracker/Endpoints/SnowplowHttpCollectorEndpoint.cs
@@ -34,7 +34,7 @@ namespace Snowplow.Tracker.Endpoints
         private readonly int POST_WRAPPER_BYTES = 88; // "schema":"iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4","data":[]
         private readonly int POST_STM_BYTES = 22;     // "stm":"1443452851000",
 
-        private readonly string _collectorUri;
+        private string _collectorUri;
         private readonly HttpMethod _method;
         private GetDelegate _getMethod;
         private PostDelegate _postMethod;
@@ -54,7 +54,7 @@ namespace Snowplow.Tracker.Endpoints
         /// <param name="byteLimitGet">The maximum amount of bytes we can expect to work</param>
         /// <param name="l">Send log messages using this logger</param>
         /// </summary>
-        public SnowplowHttpCollectorEndpoint(string host, HttpProtocol protocol = HttpProtocol.HTTP, int? port = null, HttpMethod method = HttpMethod.GET, 
+        public SnowplowHttpCollectorEndpoint(string host, HttpProtocol protocol = HttpProtocol.HTTP, int? port = null, HttpMethod method = HttpMethod.GET,
             PostDelegate postMethod = null, GetDelegate getMethod = null, int byteLimitPost = 40000, int byteLimitGet = 40000, ILogger l = null)
         {
             if (Uri.IsWellFormedUriString(host, UriKind.Absolute))
@@ -263,6 +263,28 @@ namespace Snowplow.Tracker.Endpoints
             }
         }
 
+        /// <summary>
+        /// Set the uri suffix for post requests.
+        /// </summary>
+        /// <param name="postPath">New uri suffix</param>
+        public void CustomPostPath(string postPath)
+        {
+            UriBuilder builder = new UriBuilder(_collectorUri);
+            builder.Path = postPath;
+            _collectorUri = builder.Uri.ToString();
+        }
+
+        /// <summary>
+        /// Set the uri suffix for get requests.
+        /// </summary>
+        /// <param name="getPath">New uri suffix</param>
+        public void CustomGetPath(string getPath)
+        {
+            UriBuilder builder = new UriBuilder(_collectorUri);
+            builder.Path = getPath;
+            _collectorUri = builder.Uri.ToString();
+        }
+
         // --- Event builders
 
         /// <summary>
@@ -346,7 +368,7 @@ namespace Snowplow.Tracker.Endpoints
                 using (HttpClient c = new HttpClient())
                 {
                     return ProcessRequestTask(c.GetAsync(uri));
-                } 
+                }
             });
 
             return new RequestResult()


### PR DESCRIPTION
This Pull Request proposes the addition of CustomGetPath and CustomPostPath methods to the library. These methods aim to enhance the flexibility and adaptability of the library by allowing users to dynamically update the `postpath` and `getpath` as needed.

Solution:
To address the limitation of the snowplow-dotnet-tracker library, this Pull Request introduces two new methods: CustomGetPath and CustomPostPath. These methods provide developers with the ability to customize and control the postpath and getpath for specific use cases.

Impact:
By including these new methods, the snowplow-dotnet-tracker community will benefit from improved customization options for managing postpath and getpath updates. Developers will have greater control over the tracking behavior.

Thank you for considering this Pull Request. Your feedback and suggestions are highly appreciated.

Closes #129 